### PR TITLE
Rails 6 support

### DIFF
--- a/app/views/pul-assets/blacklight/_account.html.erb
+++ b/app/views/pul-assets/blacklight/_account.html.erb
@@ -11,9 +11,6 @@
         </li>
         <% end %>
         <li>
-          <%= link_to t('blacklight.header_links.saved_searches'), blacklight.saved_searches_path %>
-        </li>
-        <li>
           <%= link_to t('blacklight.header_links.search_history'), blacklight.search_history_path %>
         </li>
         <li>

--- a/app/views/pul-assets/blacklight/catalog/_search_form.html.erb
+++ b/app/views/pul-assets/blacklight/catalog/_search_form.html.erb
@@ -11,7 +11,7 @@
     <% end %>
 
     <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
+    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?  %>
 
     <span class="input-group-btn">
       <button type="submit" class="btn btn-primary search-btn" id="search">

--- a/app/views/pul-assets/blacklight/catalog/_search_form.html.erb
+++ b/app/views/pul-assets/blacklight/catalog/_search_form.html.erb
@@ -2,7 +2,7 @@
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <div class="input-group">
     <% if search_fields.length > 1 %>
-      <span class="input-group-addon for-search-field">
+      <span class="input-group-prepend for-search-field">
         <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
         <%= select_tag(:search_field, options_for_select(search_fields, h(params[:search_field])), title: t('blacklight.search.form.search_field.title'), id: "search_field", class: "search_field") %>
       </span>

--- a/pul-assets.gemspec
+++ b/pul-assets.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bourbon", "~> 4.2.6"
   spec.add_dependency "susy", "~> 2.2.12"
   spec.add_dependency "breakpoint", "~> 2.7.0"
-  spec.add_dependency "jquery-tablesorter", "~> 1.20.5"
+  spec.add_dependency "jquery-tablesorter", "~> 1.27.2"
   spec.add_dependency "jquery-datatables-rails", "~> 3.4.0"
   spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
Should not be a very impactful change:

- Updates our jquery-tablesorter dependency
- removes an unused, out-of-date autocomplete option from a blacklight partial
- removes a line from a blacklight partial that is not currently used in any apps